### PR TITLE
Disregard element ordering in Dict tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pytest==2.9.1
 pytest-cov==2.2.1
 coverage==4.0.3
 tox==2.3.1
+six==1.10.0

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,4 +1,5 @@
 import unittest
+import six
 
 from collections_hierarchy.main import *
 
@@ -13,7 +14,7 @@ class DictTestCase(unittest.TestCase):
 
     def test_dict_iter(self):
         d1 = Dict({'a': 1, 'b': 2})
-        self.assertEqual([key for key in d1], ['a', 'b'])
+        six.assertCountEqual(self, [key for key in d1], ['a', 'b'])
 
     def test_dict_contains(self):
         d1 = Dict({'a': 1, 'b': 2})
@@ -38,10 +39,14 @@ class DictTestCase(unittest.TestCase):
         self.assertEqual(d1, Dict({'a': 1, 'b': 2, 'z': 10}))
 
     def test_dict_keys(self):
-        self.assertEqual(Dict({'a': 1, 'b': 2}).keys(), ['a', 'b'])
+        six.assertCountEqual(self, Dict({'a': 1, 'b': 2}).keys(), ['a', 'b'])
 
     def test_dict_values(self):
-        self.assertEqual(Dict({'a': 1, 'b': 2}).values(), [1, 2])
+        six.assertCountEqual(self, Dict({'a': 1, 'b': 2}).values(), [1, 2])
 
     def test_dict_items(self):
-        self.assertEqual(Dict({'a': 1, 'b': 2}).items(), [('a', 1), ('b', 2)])
+        six.assertCountEqual(
+            self, 
+            Dict({'a': 1, 'b': 2}).items(), 
+            [('a', 1), ('b', 2)]
+        )


### PR DESCRIPTION
Four of the tests in test_dict.py are comparing lists that the interpreter will create in an arbitrary order.  This is making these tests pass or fail inconsistently.

`unittest.TestCase.assertItemsEqual` in Python 2 or `unittest.TestCase.assertCountEqual` in Python 3 will test that the two sequences contain the same elements, regardless of their order.  This seems to be the behavior we want for these four tests.  (These methods are implemented in the six package as `six.assertCountEqual`.)

There are a couple other ways I thought of to fix this, if you'd like to look at alternatives.
