### PR TITLE
Added iter() call to test_mixins.py before next()

### DIFF
--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -95,22 +95,24 @@ class ComparableMixinTestCase(unittest.TestCase):
 class SequenceMixinTestCase(unittest.TestCase):
     def test_iterator_next(self):
         l = SequenceMixinList(['hello', 9, 'Python'])
-
-        self.assertEqual(next(l), 'hello')
-        self.assertEqual(next(l), 9)
-        self.assertEqual(next(l), 'Python')
+        it = iter(l)
+        
+        self.assertEqual(next(it), 'hello')
+        self.assertEqual(next(it), 9)
+        self.assertEqual(next(it), 'Python')
 
         with self.assertRaises(StopIteration):
-            next(l)
+            next(it)
 
         d = SequenceMixinDict({'a': 1, 'b': 2})
         items = list(d.data.items())
+        it = iter(items)
 
-        self.assertEqual(next(d), items[0])
-        self.assertEqual(next(d), items[1])
+        self.assertEqual(next(it), items[0])
+        self.assertEqual(next(it), items[1])
 
         with self.assertRaises(StopIteration):
-            next(d)
+            next(it)
 
     def test_iterator_is_rewinded(self):
         l = SequenceMixinList(['hello', 9, 'Python'])


### PR DESCRIPTION
There was no iter() called before next so if variables were initialized in iter() and used in next() it wouldn't find them. Now it's fixed
